### PR TITLE
Add description of case study for repository effect

### DIFF
--- a/case-studies/repository-effect/DATA_ACCESS.md
+++ b/case-studies/repository-effect/DATA_ACCESS.md
@@ -2,7 +2,7 @@
 
 ## Data Availability
 
-**Zenodo DOI**: [10.5281/zenodo.XXXXXXX](https://doi.org/10.5281/zenodo.XXXXXXX)
+**Zenodo DOI**: [10.5281/zenodo.17140194](https://doi.org/10.5281/zenodo.17140194)
 
 ### What's Available in Zenodo
 - Processed datasets used for analysis

--- a/case-studies/repository-effect/DATA_ACCESS.md
+++ b/case-studies/repository-effect/DATA_ACCESS.md
@@ -1,0 +1,28 @@
+# Data Access Information
+
+## Data Availability
+
+**Zenodo DOI**: [10.5281/zenodo.XXXXXXX](https://doi.org/10.5281/zenodo.XXXXXXX)
+
+### What's Available in Zenodo
+- Processed datasets used for analysis
+- Documentation and metadata
+
+## External Data Sources Required
+
+All datasets below are available under open licences.
+- [**OpenAlex**](https://openalex.org/): Paper metadata
+- [**CWTS field classification**](https://doi.org/10.5281/zenodo.13868129): Classification of papers into fields
+- [**Datacite**](https://datacite.org/): Metadata of datasets
+- [**Global Data Citation Corpus**](https://doi.org/10.5281/zenodo.13376773)
+
+### Common External Sources in PathOS Studies
+
+- [**Datastet**](https://github.com/kermitt2/datastet): Tool to extract data mentions, part of the broader GROBID suite.
+- **SciNoBo Toolkit**: Specialized bibliometric indicators (contact PathOS team)
+
+## Usage
+
+### For Analysis with Provided Data
+1. Download processed datasets from Zenodo
+2. Run analysis scripts with the provided data

--- a/case-studies/repository-effect/README.md
+++ b/case-studies/repository-effect/README.md
@@ -1,0 +1,44 @@
+# Repository effect: Effects of Data Repositories on Data Usage
+
+This folder contains the code, documentation, and analysis results for the repository effect case study, part of the PathOS project.
+
+## Overview
+
+This case study investigates the effect of data repositories on the use of data for research. How can we establish usage of datasets in research? Are datasets from some repositories more likely to be used for research than other repositories? What factors are relevant for those differences in usage?
+
+We were interested in the effect of the repository where data is shared on the subsequent usage of that data. For research articles, we know that it matters where an article is published for subsequent citations. Does something similar happen with citations to datasets, and are citations affected by the repository where the dataset is stored? That is, would sharing data in a particular repository result in more reuse?
+
+We analyse these effects in general, but also with a particular interest in the social sciences, based on three different studies:
+
+- we study the extent to which data usage can be automatically inferred from scholarly publications in the social sciences;
+
+- we interview scientists in the social sciences about their data usage, and what role data repositories play;
+
+- we study data usage quantitatively on the basis of the Data Citation Corpus.
+
+## Repository Contents
+
+### Analysis Scripts
+
+This repository includes core code to replicate the analysis in the PathOS case study on repositories. This only includes the essential code to reproduce the analysis, and does not include any ancillary code for producing tables and/or figures. Moreover, we do not include any code to run [`datastet`](https://github.com/kermitt2/grobid) or [`SciNoBo`](https://github.com/iNoBo/scinobo-raa), since this requires a custom setup that is documented at their respective repositories. This means that this repository only includes the code for the regression model that is used to analyse the data citations. The data that the model can be fitted to is available from https://doi.org/xxx
+
+We use [Stan](https://mc-stan.org/) to specify the regression model used to analyse the data citations. The model is available from the file `data_citations.stan`. The model is quite simple and rather self-explanatory. Stan offers various interfaces to fit the model to the data, including a command-line, Julia, Python and R interface.
+
+### Data
+- See `DATA_ACCESS.md` for information on accessing the data used in this case study
+- Processed datasets and results are deposited in Zenodo (see DATA_ACCESS.md for DOI)
+
+## Usage
+
+### To reproduce the analysis:
+1. Access the data as described in `DATA_ACCESS.md`
+2. Install [Stan](https://mc-stan.org/)
+3. Fit the model to the data
+
+## External Dependencies
+
+The analysis relies on [Stan](https://mc-stan.org/), which can be used from various interface.
+
+## Contact
+
+Please contact Vincent Traag (v.a.traag@cwts.leidenuniv.nl) for more information.

--- a/case-studies/repository-effect/data_citations.stan
+++ b/case-studies/repository-effect/data_citations.stan
@@ -1,0 +1,37 @@
+data {
+    int<lower=1> N;
+    int<lower=1> N_repositories;
+    int<lower=1> N_sources;
+    int<lower=1> N_years;
+    int<lower=1> N_fields;
+
+    array[N] int<lower=0,upper=1> is_cited;
+    array[N] int<lower=1,upper=N_repositories> repository;
+    array[N] int<lower=1,upper=N_sources> source;
+    array[N] int<lower=1,upper=N_years> year;
+    array[N] int<lower=1,upper=N_fields> field;
+}
+parameters {
+    real intercept;
+    sum_to_zero_vector[N_repositories] repository_effect;
+    sum_to_zero_vector[N_sources] source_effect;
+    sum_to_zero_vector[N_years] year_effect;
+    sum_to_zero_vector[N_fields] field_effect;
+
+}
+model {
+    // Priors
+    intercept ~ normal(0, 5);
+    repository_effect ~ normal(0, sqrt(N_repositories / (N_repositories - 1.0)));
+    source_effect ~ normal(0, sqrt(N_sources / (N_sources - 1.0)));
+    year_effect ~ normal(0, sqrt(N_years / (N_years - 1.0)));
+    field_effect ~ normal(0, sqrt(N_fields / (N_fields - 1.0)));
+
+    // Main model
+    is_cited ~ bernoulli_logit(intercept +
+                               repository_effect[repository] +
+                               source_effect[source] +
+                               year_effect[year] +
+                               field_effect[field]);
+}
+


### PR DESCRIPTION
This adds the requested details for the repository effect case study. I've decided not to include the scripts for plotting figures and making tables. I don't consider that essential code for the analysis, and I never add it to replication code. 

In addition, the (SQL) scripts for creating an integrated dataset relies on a huge infrastructure at CWTS that contains all the necessary data. It is a bit useless to make this available, since it requires setting up the entire infrastructure in order to be able to run it.

The data itself is described in more detail in the data repository. (I will update the DOI in the `DATA_ACCESS.md` file once that is available).

Finally, I also decided not to include results, since they are already contained in the report itself.